### PR TITLE
Improving support of ModSec

### DIFF
--- a/wafamole/cli.py
+++ b/wafamole/cli.py
@@ -1,5 +1,6 @@
 import click
 import pickle
+import re
 from wafamole.evasion import EvasionEngine
 from wafamole.evasion.random import RandomEvasionEngine
 from wafamole.exceptions.models_exceptions import UnknownModelError
@@ -67,9 +68,10 @@ def evade(
         model = SQLiGoTWrapper(undirected=False, proportional=True).load(model_path)
     elif model_type == "waf-brain":
         model = WafBrainWrapper(model_path)
-    elif model_type == "modsecurity":
+    elif re.match(r"modsecurity_pl[1-4]", model_type):
+        pl = int(model_type[-1])
         try:
-            model = PyModSecurityWrapper(model_path)
+            model = PyModSecurityWrapper(model_path, pl)
         except:
             print("ModSecurity wrapper is not installed, see https://github.com/AvalZ/pymodsecurity to install")
             exit()


### PR DESCRIPTION
Hello,
this PR aims to improve the support of ModSec in WAF-a-MoLE:
- Better handling of PL when using cli. This may fix #8 (?).
- Improving the implementation of `PyModSecurityWrapper` and removing some unused code in `modsec_wrapper.py`.

NOTES:
- Pls, do not merge yet because I'd like to perform additional tests.
- I would also add a further check in the constructor of `PyModSecurityWrapper` in order to ensure that the PL version passed by cli equals the PL values specified in the config file (usually `crs-setup.conf`).