### PR TITLE
New improvements

### DIFF
--- a/wafamole/evasion/evasion.py
+++ b/wafamole/evasion/evasion.py
@@ -104,7 +104,7 @@ class EvasionEngine(CoreEngine):
 
         print(
             "Reached confidence {}\nwith payload\n{}".format(
-                min_confidence, min_payload
+                min_confidence, repr(min_payload)
             )
         )
 

--- a/wafamole/models/modsec_wrapper.py
+++ b/wafamole/models/modsec_wrapper.py
@@ -80,7 +80,7 @@ class PyModSecurityWrapper(Model):
     def classify(self, value):
 
         method = "GET"
-        base_uri = "http://www.modsecurity.org/test",
+        base_uri = "http://www.modsecurity.org/test"
         encoded_query = urlencode({'q': value})
         full_url = f"{base_uri}?{encoded_query}"
         parsed_url = urlparse(full_url)

--- a/wafamole/payloadfuzzer/fuzz_utils.py
+++ b/wafamole/payloadfuzzer/fuzz_utils.py
@@ -23,11 +23,10 @@ def replace_nth(candidate, sub, wanted, n):
     type_check(sub, str, "sub")
     type_check(wanted, str, "wanted")
     type_check(n, int, "n")
-    where = [m.start() for m in re.finditer(re.escape(sub), candidate)][n - 1]
-    before = candidate[:where]
-    after = candidate[where:]
-    after = after.replace(sub, wanted, 1)
-    result = before + after
+    match = [m for m in re.finditer(re.escape(sub), candidate)][n - 1]
+    before = candidate[:match.start()]
+    after = candidate[match.end():]
+    result = before + wanted + after
     return result
 
 
@@ -48,18 +47,17 @@ def replace_random(candidate, sub, wanted):
     type_check(candidate, str, "candidate")
     type_check(sub, str, "sub")
     type_check(wanted, str, "wanted")
-    occurrences = [m.start() for m in re.finditer(sub, candidate)]
+
+    occurrences = list(re.finditer(sub, candidate))
     if not occurrences:
         return candidate
 
-    pos = random.choice(occurrences)
+    match = random.choice(occurrences)
 
-    before = candidate[:pos]
-    after = candidate[pos:]
-    # after = after.replace(sub, wanted, 1)
-    after = re.sub(sub, wanted, after, 1)
+    before = candidate[:match.start()]
+    after = candidate[match.end():]
+    result = before + wanted + after
 
-    result = before + after
     return result
 
 
@@ -98,9 +96,10 @@ def random_char(spaces=True):
     """
 
     type_check(spaces, bool, "spaces")
-    chars = list(string.printable)
-    chars_no_space = [c for c in chars if c not in string.whitespace]
-    return random.choice(chars if spaces else chars_no_space)
+    chars = string.digits + string.ascii_letters + string.punctuation
+    if spaces:
+        chars += string.whitespace
+    return random.choice(chars)
 
 
 def random_string(max_len=5, spaces=True):
@@ -138,15 +137,15 @@ def string_tautology():
         # Strings - equals
         "'{}'='{}'".format(value_s, value_s),
         "'{}' LIKE '{}'".format(value_s, value_s),
-        '"{}"="{}"'.format(value_s, value_s),
-        '"{}" LIKE "{}"'.format(value_s, value_s),
+        "'{}'='{}'".format(value_s, value_s),
+        "'{}' LIKE '{}'".format(value_s, value_s),
         # Strings - not equal
         "'{}'!='{}'".format(value_s, value_s + random_string(1, spaces=False)),
         "'{}'<>'{}'".format(value_s, value_s + random_string(1, spaces=False)),
         "'{}' NOT LIKE '{}'".format(value_s, value_s + random_string(1, spaces=False)),
-        '"{}"!="{}"'.format(value_s, value_s + random_string(1, spaces=False)),
-        '"{}"<>"{}"'.format(value_s, value_s + random_string(1, spaces=False)),
-        '"{}" NOT LIKE "{}"'.format(value_s, value_s + random_string(1, spaces=False)),
+        "'{}'!='{}'".format(value_s, value_s + random_string(1, spaces=False)),
+        "'{}'<>'{}'".format(value_s, value_s + random_string(1, spaces=False)),
+        "'{}' NOT LIKE '{}'".format(value_s, value_s + random_string(1, spaces=False)),
     ]
 
     return random.choice(tautologies)
@@ -164,15 +163,15 @@ def string_contradiction():
         # Strings - equals
         "'{}'='{}'".format(value_s, value_s + random_string(1, spaces=False)),
         "'{}' LIKE '{}'".format(value_s, value_s + random_string(1, spaces=False)),
-        '"{}"="{}"'.format(value_s, value_s + random_string(1, spaces=False)),
-        '"{}" LIKE "{}"'.format(value_s, value_s + random_string(1, spaces=False)),
+        "'{}'='{}'".format(value_s, value_s + random_string(1, spaces=False)),
+        "'{}' LIKE '{}'".format(value_s, value_s + random_string(1, spaces=False)),
         # Strings - not equal
         "'{}'!='{}'".format(value_s, value_s),
         "'{}'<>'{}'".format(value_s, value_s),
         "'{}' NOT LIKE '{}'".format(value_s, value_s),
-        '"{}"!="{}"'.format(value_s, value_s),
-        '"{}"<>"{}"'.format(value_s, value_s),
-        '"{}" NOT LIKE "{}"'.format(value_s, value_s),
+        "'{}'!='{}'".format(value_s, value_s),
+        "'{}'<>'{}'".format(value_s, value_s),
+        "'{}' NOT LIKE '{}'".format(value_s, value_s),
     ]
 
     return random.choice(contradictions)

--- a/wafamole/payloadfuzzer/sqlfuzzer.py
+++ b/wafamole/payloadfuzzer/sqlfuzzer.py
@@ -49,7 +49,6 @@ def logical_invariant(payload):
     :param payload:
     """
 
-    # pos = re.search("(#|-- )", payload)
     pos = re.search(r"\b\w+(\s*(=|!=|<>|>|<|>=|<=)\s*|\s+(?i:like|not like)\s+)\w+\b", payload)
 
     if not pos:
@@ -79,13 +78,12 @@ def logical_invariant(payload):
 
 
 def change_tautologies(payload):
-    # results = list(re.finditer(r'((?<=[^\'"\d\wx])\d+(?=[^\'"\d\wx]))=\1', payload))
     # rules matching numeric tautologies
     num_tautologies_pos = list(re.finditer(r'\b(\d+)(\s*=\s*|\s+(?i:like)\s+)\1\b', payload))
     num_tautologies_neg = list(re.finditer(r'\b(\d+)(\s*(!=|<>)\s*|\s+(?i:not like)\s+)(?!\1\b)\d+\b', payload))
     # rule matching string tautologies
-    string_tautologies_pos = list(re.finditer(r'(\'|\")([a-zA-Z]{1}[\w#@$]*)\1(\s*=\s*|\s+(?i:like)\s+)(\'|\")\2\5', payload))
-    string_tautologies_neg = list(re.finditer(r'(\'|\")([a-zA-Z]{1}[\w#@$]*)\1(\s*(!=|<>)\s*|\s+(?i:not like)\s+)(\'|\")(?!\2)([a-zA-Z]{1}[\w#@$]*)\6', payload))
+    string_tautologies_pos = list(re.finditer(r'(\'|\")([a-zA-Z]{1}[\w#@$]*)\1(\s*=\s*|\s+(?i:like)\s+)(\'|\")\2\4', payload))
+    string_tautologies_neg = list(re.finditer(r'(\'|\")([a-zA-Z]{1}[\w#@$]*)\1(\s*(!=|<>)\s*|\s+(?i:not like)\s+)(\'|\")(?!\2)([a-zA-Z]{1}[\w#@$]*)\5', payload))
     results = num_tautologies_pos + num_tautologies_neg + string_tautologies_pos + string_tautologies_neg
     if not results:
         return payload
@@ -176,7 +174,6 @@ def comment_rewriting(payload):
 
 def swap_int_repr(payload):
 
-    # candidates = list(re.finditer(r'(?<=[^\'"\d\wx])\d+(?=[^\'"\d\wx])', payload))
     candidates = list(re.finditer(r'\b\d+\b', payload))
 
     if not candidates:
@@ -222,7 +219,6 @@ def swap_keywords(payload):
         "like": ["LIKE", "="]
     }
 
-    # symbols_in_payload = [s for s in symbols if re.search(r'{}'.format(s), payload)]
     symbols_in_payload = []
     for symbol in symbols:
         if symbol in ["OR", "or", "AND", "and", "LIKE", "like", "NOT LIKE", "not like"]:

--- a/wafamole/payloadfuzzer/sqlfuzzer.py
+++ b/wafamole/payloadfuzzer/sqlfuzzer.py
@@ -49,13 +49,20 @@ def logical_invariant(payload):
     :param payload:
     """
 
-    pos = re.search(r"\b\w+(\s*(=|!=|<>|>|<|>=|<=)\s*|\s+(?i:like|not like)\s+)\w+\b", payload)
-
-    if not pos:
-        # No comments found
+    # pos = re.search(r"(\b\d+|(\'|\")([a-zA-Z]{1}[\w#@$]*)\2)(\s*(=|!=|<>|>|<|>=|<=)\s*|\s+(?i:like|not like)\s+)(\d+\b|(\'|\")([a-zA-Z]{1}[\w#@$]*)\2)", payload)
+    # if not pos:
+    #     return payload
+    num_tautologies_pos = list(re.finditer(r'\b(\d+)(\s*=\s*|\s+(?i:like)\s+)\1\b', payload))
+    num_tautologies_neg = list(re.finditer(r'\b(\d+)(\s*(!=|<>)\s*|\s+(?i:not like)\s+)(?!\1\b)\d+\b', payload))
+    # rule matching string tautologies
+    string_tautologies_pos = list(re.finditer(r'(\'|\")([a-zA-Z]{1}[\w#@$]*)\1(\s*=\s*|\s+(?i:like)\s+)(\'|\")\2\4', payload))
+    string_tautologies_neg = list(re.finditer(r'(\'|\")([a-zA-Z]{1}[\w#@$]*)\1(\s*(!=|<>)\s*|\s+(?i:not like)\s+)(\'|\")(?!\2)([a-zA-Z]{1}[\w#@$]*)\5', payload))
+    results = num_tautologies_pos + num_tautologies_neg + string_tautologies_pos + string_tautologies_neg
+    if not results:
         return payload
+    pos = random.choice(results)
 
-    pos = pos.start()
+    pos = pos.end()
 
     replacement = random.choice(
         [

--- a/wafamole/payloadfuzzer/sqlfuzzer.py
+++ b/wafamole/payloadfuzzer/sqlfuzzer.py
@@ -157,7 +157,13 @@ def spaces_to_whitespaces_alternatives(payload):
 def random_case(payload):
 
     tokens = []
-    for t in sqlparse.parse(payload):
+    # Check if the payload is correctly parsed (safety check).
+    try:
+        parsed_payload = sqlparse.parse(payload)
+    except Exception:
+        # Just return the input payload if it cannot be parsed to avoid stopping the fuzzing
+        return payload
+    for t in parsed_payload:
         tokens.extend(list(t.flatten()))
 
     sql_keywords = set(sqlparse.keywords.KEYWORDS_COMMON.keys())
@@ -237,7 +243,13 @@ def swap_keywords(payload):
     # Use sqlparse to tokenize the payload in order to better match keywords,
     # even when they are composed by multiple keywords such as "NOT LIKE"
     tokens = []
-    for t in sqlparse.parse(payload):
+    # Check if the payload is correctly parsed (safety check).
+    try:
+        parsed_payload = sqlparse.parse(payload)
+    except Exception:
+        # Just return the input payload if it cannot be parsed to avoid stopping the fuzzing
+        return payload
+    for t in parsed_payload:
         tokens.extend(list(t.flatten()))
 
     indices = [idx for idx, token in enumerate(tokens) if token.value in replacements]

--- a/wafamole/payloadfuzzer/sqlfuzzer.py
+++ b/wafamole/payloadfuzzer/sqlfuzzer.py
@@ -49,9 +49,7 @@ def logical_invariant(payload):
     :param payload:
     """
 
-    # pos = re.search(r"(\b\d+|(\'|\")([a-zA-Z]{1}[\w#@$]*)\2)(\s*(=|!=|<>|>|<|>=|<=)\s*|\s+(?i:like|not like)\s+)(\d+\b|(\'|\")([a-zA-Z]{1}[\w#@$]*)\2)", payload)
-    # if not pos:
-    #     return payload
+    # rule matching numeric tautologies
     num_tautologies_pos = list(re.finditer(r'\b(\d+)(\s*=\s*|\s+(?i:like)\s+)\1\b', payload))
     num_tautologies_neg = list(re.finditer(r'\b(\d+)(\s*(!=|<>)\s*|\s+(?i:not like)\s+)(?!\1\b)\d+\b', payload))
     # rule matching string tautologies


### PR DESCRIPTION
Hello,
this PR introduces new important changes and improvements to WAF-a-MoLE:
- Improve manipulations:
  - `change_tautologies`: fix regex
  - `logical_invariant`: add same regex of `change_tautologies` and fix replacement
  - `random_case`: apply case swapping only on SQL keywords extracted using sqlparse
  - `swap_keywords`: rewrite manipulation using sqlparse to tokenize the payload in order to better match keywords even      when they are composed by multiple tokens such as "NOT LIKE".
  - `shuffle_integers`: remove the manipulation because it is a special case of `change_tautologies`. Moreover, the new string that are inserted are not quoted. Is this not valid w.r.t. the SQL grammar, right?
  
- Improve utilities:
  - `replace_random`: The previous implementation has been converted to an equivalent one. The first reason is that we do not need to match the `sub` pattern two times because we already use `re.finditer()` few lines above. The second one it is because sometimes it generates some error. But, abut this second point I haven't investigate in details. Anyway, this new solutions does not generate errors anymore.
  - `replace_nth`: small improvement to match the same implementation of `replace_random`.
  - `random_string`: quote strings using single quotes for all the replacements

**[UPDATE]**: I have performed several tests with ModSec and the latest CRS release (4.0) and all passed successfully.
Specifically, the changes have been successfully tested on a dataset of SQLi payloads considering all the PL.
I also implemented some unit tests to evaluate the changes to the manipulations in [my test_improvements branch](https://github.com/biagiom/WAF-A-MoLE/blob/test_improvements/tests/test_manipulations.py) and all of them passed.